### PR TITLE
Kubernetes intro

### DIFF
--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  containers:
+    - name: frontend
+      image: metalrex100/study-kubernetes:microservices_frontend
+      imagePullPolicy: Always
+      env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: metalrex100/study-kubernetes:microservices_frontend
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+    - name: web
+      image: metalrex100/study-kubernetes:test_nginx
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  initContainers:
+    - name: init-web
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx
+
+WORKDIR /app
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 8000

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,14 @@
+server {
+    listen       8000;
+    server_name  localhost;
+
+    location / {
+       root /app;
+       autoindex on;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [✅] Основное ДЗ
 - [✅] Задание со *

## В процессе сделано:
 - Создан Dockerfile с описанием docker-образа веб-сервера nginx
 - Создан манифест пода `web`
 - Создан рабочий манифест пода `frontend`

## Как запустить проект:
 - В репозитории выполнить команду `kubectl apply -f kubernetes-intro/web-pod.yaml`
 - В репозитории выполнить команду `kubectl apply -f kubernetes-intro/frontend-pod-healty.yaml`
 - Выполнить команду `kubectl port-forward --address 0.0.0.0 pod/web 8000:8000`

## Как проверить работоспособность:
 - Перейти по ссылке http://localhost:8000

## PR checklist:
 - [✅] Выставлен label с темой домашнего задания

## Ответы на вопросы в ДЗ
1) Разберитесь почему все pod в namespace kube-system
восстановились после удаления.
 - под `core-dns` находится под контролем **ReplicaSet**, поды `kube-*` находятся под управлением **Node/minikube**. Скорее всего, сервисы в неймспейсе `kube-system` создаются и управляются мастер-нодой. Но это не точно. Буду рад комментарию :)

2) Выясните причину, по которой pod frontend находится в статусе
Error
 - Ошибка происходила ввиду того, что golang-приложению `frontend` для запуска были необходимы значения ENV-переменных, которые при запуске пода без манифеста не передавались.